### PR TITLE
Fix multiple derive calls in the same file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- Fix: Multiple `#[derive(CachDiff)]` calls in the same file now work (https://github.com/heroku-buildpacks/cache_diff/pull/4)
+
 ## 1.0.0
 
 - Changed: Error when deriving CacheDiff when zero comparison fields are found. This can happen if the struct has no fields or if all fields are `ignore`-d (https://github.com/schneems/cache_diff/pull/4)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "1e038a9e6b7e36319ab42141434b0c7a93f7714aa90abf63cc5086e106027bb7"
 
 [[package]]
 name = "cache_diff"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bullet_stream",
  "cache_diff_derive",
@@ -18,7 +18,7 @@ dependencies = [
 
 [[package]]
 name = "cache_diff_derive"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bullet_stream",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 rust-version = "1.82"
 edition = "2021"
 license = "Apache-2.0"

--- a/cache_diff_derive/src/fields.rs
+++ b/cache_diff_derive/src/fields.rs
@@ -105,9 +105,7 @@ pub fn create_cache_diff(item: TokenStream) -> syn::Result<TokenStream> {
         ))
     } else {
         Ok(quote! {
-            #[allow(clippy::useless_attribute)]
-            use cache_diff as _cache_diff;
-            impl _cache_diff::CacheDiff for #struct_identifier {
+            impl cache_diff::CacheDiff for #struct_identifier {
                 fn diff(&self, old: &Self) -> Vec<String> {
                     let mut differences = Vec::new();
                     #(#comparisons)*

--- a/usage/src/multiple_structs.rs
+++ b/usage/src/multiple_structs.rs
@@ -1,0 +1,34 @@
+// Ensure multiple derives can be in the same file
+#[derive(CacheDiff)]
+struct Dog {
+    woof: String,
+}
+#[allow(dead_code)]
+#[derive(CacheDiff)]
+struct Cat {
+    meow: String,
+}
+#[cfg(test)]
+mod test {
+    use super::*;
+    #[test]
+    fn test_cat() {
+        let diff = Cat {
+            meow: "Meow".to_string(),
+        }
+        .diff(&Cat {
+            meow: "Woem".to_string(),
+        });
+        assert!(diff.len() == 1);
+    }
+    #[test]
+    fn test_dog() {
+        let diff = Dog {
+            woof: "Woof".to_string(),
+        }
+        .diff(&Dog {
+            woof: "Foow".to_string(),
+        });
+        assert!(diff.len() == 1);
+    }
+}


### PR DESCRIPTION
I emulated the `use` line off of a similar `extern` line from serde, don't entirely remember the reason why. I can use the full path to the trait and we don't need to import/use anything. This fixes issue #3

Close #3