### PR TITLE
Fix failing Clippy lints

### DIFF
--- a/cache_diff/src/lib.rs
+++ b/cache_diff/src/lib.rs
@@ -15,8 +15,8 @@
 //!
 //! - `#[cache_diff(rename = "<new name>")]` Specify custom name for the field
 //! - `#[cache_diff(ignore)]` or `#[cache_diff(ignore = "<reason>")]` Ignores the given field with an optional comment string.
-//!    If the field is ignored because you're using a custom diff function (see container attributes) you can use
-//!    `cache_diff(ignore = "custom")` which will check that the container implements a custom function.
+//!   If the field is ignored because you're using a custom diff function (see container attributes) you can use
+//!   `cache_diff(ignore = "custom")` which will check that the container implements a custom function.
 //!
 //! ## Why
 //!
@@ -249,7 +249,7 @@ pub trait CacheDiff {
     /// Enable ANSI colors with `features = ["bullet_stream"]`
     #[cfg(not(feature = "bullet_stream"))]
     fn fmt_value<T: std::fmt::Display>(&self, value: &T) -> String {
-        format!("`{}`", value)
+        format!("`{value}`")
     }
 }
 pub use cache_diff_derive::CacheDiff;

--- a/cache_diff_derive/src/cache_diff_container.rs
+++ b/cache_diff_derive/src/cache_diff_container.rs
@@ -165,7 +165,7 @@ mod test {
         };
 
         let result = CacheDiffContainer::from_ast(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"No fields to compare for CacheDiff, ensure struct has at least one named field that isn't `cache_diff(ignore)`-d"#
@@ -179,7 +179,7 @@ mod test {
         };
 
         let result = CacheDiffContainer::from_ast(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"No fields to compare for CacheDiff, ensure struct has at least one named field that isn't `cache_diff(ignore)`-d"#
@@ -196,7 +196,7 @@ mod test {
         };
 
         let result = CacheDiffContainer::from_ast(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"field `version` on Metadata marked ignored as custom, but no `#[cache_diff(custom = <function>)]` found on `Metadata`"#

--- a/cache_diff_derive/src/cache_diff_field.rs
+++ b/cache_diff_derive/src/cache_diff_field.rs
@@ -323,7 +323,7 @@ mod test {
         );
 
         let result = ParsedField::from_field(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()).trim(),
             formatdoc! {"
@@ -345,7 +345,7 @@ mod test {
             },
         );
         let result = ParsedField::from_field(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"Unknown cache_diff attribute: `unknown`. Must be one of `rename`, `display`, `ignore`"#
@@ -363,7 +363,7 @@ mod test {
             },
         );
         let result = ParsedField::from_field(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"The cache_diff attribute `ignore` renders other attributes useless, remove additional attributes"#
@@ -378,7 +378,7 @@ mod test {
             },
         );
         let result = ParsedField::from_field(&input);
-        assert!(result.is_err(), "Expected an error, got {:?}", result);
+        assert!(result.is_err(), "Expected an error, got {result:?}");
         assert_eq!(
             format!("{}", result.err().unwrap()),
             r#"The cache_diff attribute `ignore` renders other attributes useless, remove additional attributes"#


### PR DESCRIPTION
These were failing on `main`.

Mostly fixed via `cargo clippy --fix`.