### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 #ECCN:Open Source
 #GUSINFO:Languages,Buildpacks Shared Tooling
-* @heroku-buildpacks/languages
+* @schneems


### PR DESCRIPTION
Since:
- The Ruby CNB is the only consumer of this crate, and afaik the rest of us don't have any plans to start using it.
- I would prefer not to get Dependabot PR review requests for this repo.